### PR TITLE
Action Area to bottom right

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -64,7 +64,7 @@ body {
 .action-area{
     width: auto;
     position: fixed;
-    top:20px;
+    bottom:20px;
     right: 75px;
 }
 .action-area>ul.menus {


### PR DESCRIPTION
I have been using this extension at work for a few months now.

I love it, but the biggest problem I have, is that the menu is always blocking some text on the screen. This is because you can scroll left and right, to bring text onto the screen, but because the Action Area is fixed, the text is below the menu.

Moving the menu to the bottom right corner, the chance of this being a problem is significantly reduced.

A long term solution, might be to add a header that is actually a block element, so that text will never float under it.