### PR TITLE
Close menu on click

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,7 +57,7 @@ class App extends Component {
                     {
                         this.state.selectedTab === 'chart' &&
                         <ChartViews
-                            rootData = {this.state.json}
+                            rootData={this.state.json}
                             data={this.state.selectedJSON}
                             changeTargetNodeOnChart={this.changeTargetNodeOnChart.bind(this)}
                         />
@@ -71,7 +71,7 @@ class App extends Component {
                     }
 
                 </div>
-                <a href={window.optionPageURL} target="_blank" className='option-menu' id="option-menu" title="Options" style={{padding: '0px'}}><img id="option-menu-icon" src="images/icons/gear.png"/></a>
+                <a href={window.optionPageURL} target="_blank" className='option-menu' id="option-menu" title="Options" style={{padding: '0px'}}><img role="presentation" id="option-menu-icon" src="images/icons/gear.png"/></a>
             </div>
         );
     }

--- a/src/ChartView.js
+++ b/src/ChartView.js
@@ -26,7 +26,7 @@ class ChartView extends Component {
     createNewNodeValue(depthPath) {
         let nodeData = this.props.data;
         let pathSequence = [...depthPath];
-        if (pathSequence.length == 1) {
+        if (pathSequence.length === 1) {
             return this.state.rootState;
         }
         pathSequence.reverse().splice(0, 1);
@@ -75,7 +75,7 @@ class ChartView extends Component {
                 let updateTargetPath = false;
                 let selectedNodeName = this.createValidPath(data.name);//data.value || data.object || data.children;
                 if ((this.state.breadcrumbs[this.state.breadcrumbs.length - 1] !== targetNode.name && targetNode.depth !== 1) ||
-                    (this.state.breadcrumbs[this.state.breadcrumbs.length - 1] !== targetNode.name && targetNode.depth == 1)
+                    (this.state.breadcrumbs[this.state.breadcrumbs.length - 1] !== targetNode.name && targetNode.depth === 1)
                 ) {
                     updateTargetPath = true;
                     hirarchy = [data.name];
@@ -94,7 +94,7 @@ class ChartView extends Component {
                 let paths = hirarchy;
                 const newNodeData = this.createNewNodeValue(paths);
                 let newNode = {};
-                if (targetNode.depth == 0) {
+                if (targetNode.depth === 0) {
                     newNode = { ...newNodeData };
                 } else {
                     newNode[selectedNodeName] = newNodeData;

--- a/src/JSONInput.js
+++ b/src/JSONInput.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { initPlugin } from './utils/json-viewer/jquery.json-viewer.js';
 
 class JSONInput extends Component {
     constructor(props) {
@@ -30,7 +29,7 @@ class JSONInput extends Component {
                         ...this.state.errors,
                         rawJSON: {
                             ...this.state.errors.rawJSON,
-                            ... {
+                            ...{
                                 status: true
                             }
                         }
@@ -51,7 +50,7 @@ class JSONInput extends Component {
                         ...this.state.errors,
                         jsonParseFailed: {
                             ...this.state.errors.jsonParseFailed,
-                            ... {
+                            ...{
                                 status: true
                             }
                         }
@@ -69,13 +68,13 @@ resetErrors() {
                 ...this.state.errors,
                 jsonParseFailed: {
                     ...this.state.errors.jsonParseFailed,
-                    ... {
+                    ...{
                         status: false
                     }
                 },
                 rawJSON: {
                     ...this.state.errors.rawJSON,
-                    ... {
+                    ...{
                         status: false
                     }
                 }

--- a/src/TreeView.js
+++ b/src/TreeView.js
@@ -36,14 +36,12 @@ class TreeView extends Component {
         selection.addRange(selRange);
         document.execCommand("Copy");
         document.body.removeChild(selElement);
-        this.showCopier = false;
-        this.render();
+        this.setState({showCopier: false});
     }
 
     changeCopyIconLocation(e) {
         const self = this;
         this.findPath(self, e);
-        console.log('I am ');
         self.setState({
             top: $(e.target).offset().top,
             showCopier: true
@@ -121,7 +119,6 @@ class TreeView extends Component {
     componentDidMount() {
         window.json = this.props.data;
         this.$node = $(this.refs.jsonRenderer);
-        console.log('component is up babe');
         if ($) {
             const pluginOptions = {
                 collapsed: false,
@@ -149,7 +146,6 @@ class TreeView extends Component {
     }
 
     render() {
-        console.log("Current copier status: " + this.showCopier);
         window.json = this.props.data;
         return (
             <div>

--- a/src/TreeView.js
+++ b/src/TreeView.js
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
-var $ = require('jquery');
-var jQuery = $;
-import { initPlugin } from './utils/json-viewer/jquery.json-viewer.js';
 import './utils/json-viewer/jquery.json-viewer.css';
+import { initPlugin } from './utils/json-viewer/jquery.json-viewer.js';
+var $ = require('jquery');
 
 class TreeView extends Component {
     constructor(props) {
@@ -38,11 +36,14 @@ class TreeView extends Component {
         selection.addRange(selRange);
         document.execCommand("Copy");
         document.body.removeChild(selElement);
+        this.showCopier = false;
+        this.render();
     }
 
     changeCopyIconLocation(e) {
         const self = this;
         this.findPath(self, e);
+        console.log('I am ');
         self.setState({
             top: $(e.target).offset().top,
             showCopier: true
@@ -83,14 +84,14 @@ class TreeView extends Component {
         let nodes = $(e.target).parentsUntil("#json-rb");
         $(nodes).each(function (i, node) {
 
-            if ($(node).get(0).tagName == "LI" && $(node).parent()[0].tagName == "UL") {
+            if ($(node).get(0).tagName === "LI" && $(node).parent()[0].tagName === "UL") {
                 let parentKey = $(node).find("span.property").eq(0).text();
-                keys.push(self.getArrayIndex(parentKey.replace(/\"+/g, '')));
+                keys.push(self.getArrayIndex(parentKey.replace(/"+/g, '')));
             }
 
-            if ($(node).get(0).tagName == "LI" && $(node).parent()[0].tagName == "OL") {
+            if ($(node).get(0).tagName === "LI" && $(node).parent()[0].tagName === "OL") {
                 var parentKey = $(node).parent("OL").parent("li").find("span.property").eq(0).text() + '[' + $(node).index() + ']';
-                keys.push(self.getArrayIndex(parentKey.replace(/\"+/g, '')));
+                keys.push(self.getArrayIndex(parentKey.replace(/"+/g, '')));
             }
 
         });
@@ -120,7 +121,7 @@ class TreeView extends Component {
     componentDidMount() {
         window.json = this.props.data;
         this.$node = $(this.refs.jsonRenderer);
-
+        console.log('component is up babe');
         if ($) {
             const pluginOptions = {
                 collapsed: false,
@@ -131,7 +132,7 @@ class TreeView extends Component {
             $(document).on("click", "a.json-toggle", this.toggleSection);
 
           setTimeout(() => {
-                if ((window.extensionOptions || {}).collapsed == true) {
+                if ((window.extensionOptions || {}).collapsed === true) {
                 $.each($('a.json-toggle'), function (index, item) {
                     if (index > 0) {
                         $(item).trigger('click');
@@ -148,6 +149,7 @@ class TreeView extends Component {
     }
 
     render() {
+        console.log("Current copier status: " + this.showCopier);
         window.json = this.props.data;
         return (
             <div>


### PR DESCRIPTION
This PR does the following:
1) Closes the copy popup on click which is more intuitive than hovering outside.
2) Refactor code to remove JSX warnings (=== in place of ==, not following JSX conventions, spaces etc)
