### PR TITLE
Prevent text selection in action area

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -66,6 +66,7 @@ body {
     position: fixed;
     top:20px;
     right: 75px;
+    user-select: none;
 }
 .action-area>ul.menus {
     margin:0;


### PR DESCRIPTION
When selecting everything (cmd + a) and copying "TreeChartJSON Input" is prepended. Making the text within the action area non selectable fixes this.