### PR TITLE
Add way to filter out specific sites

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,23 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import './index.css';
 
+function isNextJSApplication() {
+    return !!document.getElementById("__next");
+}
+
+function shouldNotBeConsideredJSON() {
+    const redFlags = [
+        isNextJSApplication
+    ];
+
+    return redFlags.some(flag => flag() === true);
+}
+
 window.addEventListener("DOMContentLoaded", function () {
+    if (shouldNotBeConsideredJSON()) {
+        return;
+    }
+    
     const content = document.body.textContent;
     try {
         const jsonData = JSON.parse(content.trim());


### PR DESCRIPTION
Client-Side rendered Next.js applications will return a valid JSON for `document.body.textContent`, since they're preconfigured with that stuff. This will trigger this extension and thus break those kinds of sites.
You can reproduce this behaviour by going to https://demo.ente.app with an earlier version of this extension.

This PR introduces a way to check sites for "red flags", which are basically just predicates that prevent a page from being picked up by this extension. For Next.js apps, this this is the existance of `div#__next`.