### PR TITLE
Accept missing quotes in prop names and trailing commas

### DIFF
--- a/src/JSONInput.js
+++ b/src/JSONInput.js
@@ -46,6 +46,10 @@ class JSONInput extends Component {
         }
 
         try {
+            // Accept JSON properties without quotes => https://stackoverflow.com/a/24175850
+            rawJSON = rawJSON.replace(/(['"])?([a-zA-Z0-9_]+)(['"])?:([^\/])/g, '"$2":$4');
+            // Accept JSON with trailing commas => https://stackoverflow.com/a/34347475
+            rawJSON = rawJSON.replace(/\,(?=\s*?[\}\]])/g, '');
             const json = JSON.parse(rawJSON);
             this.props.changeJSON(json);
         } catch (e) {


### PR DESCRIPTION
This change will accept JSON variables copied from VSCode Watch

e.g.
```
{
    success: {
        message: "Welcome to JSON Viewer Pro",
        status_code: 200,
    }
}
```